### PR TITLE
Fixed site length incorrect formatting

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -62,7 +62,7 @@ body {
 }
 
 #header {
-    width: 625px;
+    width: 675px;
     float: right;
     margin-right: 20px;
     margin-bottom: 20px;
@@ -221,7 +221,7 @@ pre code {
 }
 
 #sites li a {
-    width: 205px;
+    width: 215px;
     padding-bottom: 30px;
     margin-bottom: 10px;
     float: left;
@@ -985,7 +985,6 @@ pre code {
 #footer {
     clear: both;
     line-height: 1.4em;
-    margin: 20px 20px 0 155px;
     padding: 12px 30px 20px 30px;
     border-top: 1px solid #999;
     text-align: center;


### PR DESCRIPTION
Fixed issue that appears via PPCG's name in the recent elections:

![screen shot 2016-03-22 at 9 55 09 am](https://cloud.githubusercontent.com/assets/12711960/13937858/2f3b4e38-f014-11e5-863d-f90eda016741.png)

By expanding the main width by 50 and the icons by 15, the text fits.

However, the footer looked a bit messy, so I got rid of the margin, which seemed to make it look pretty again.
